### PR TITLE
Add check for EOF when tokenizing identifier.

### DIFF
--- a/tools/tokenizer/tokenize.c
+++ b/tools/tokenizer/tokenize.c
@@ -390,8 +390,9 @@ int tokenize(char *token, const char **type, unsigned *line, unsigned *col)
     if (isalpha(cc) || cc == '_' || cc == '$' || cc & 0x80) {
       // First char always fits.
       token[len++] = cc;
-      while (isalnum(cc = get()) || cc == '_' || cc == '$' || cc & 0x80)
+      while ((isalnum(cc = get()) || cc == '_' || cc == '$' || cc & 0x80) && cc != EOF) {
         token_add(cc);
+	}
       unget(cc);
       *type = is_keyword(token, len) ? "keyword" : "identifier";
       break;


### PR DESCRIPTION
Example of fail case:
...

If there is no new line at the end of the file, then this will cause an infinite loop.